### PR TITLE
Correcte spelling WordPress

### DIFF
--- a/ervaren-webontwikkelaar-informatie-architect.md
+++ b/ervaren-webontwikkelaar-informatie-architect.md
@@ -7,10 +7,10 @@ Dan was jij degene die we zochten.
 
 In het Nieuwe Media Team van NRC Digitaal ben jij degene die de informatie-architectuur vaststelt en doorontwikkelt. Daarnaast werk je met een team van webontwikkelaars aan applicaties en sites, waaronder [nrc.nl](http://www.nrc.nl), de [digitale editie](http://digitaleeditie.nrc.nl) en de [registratieservice](https://login.nrc.nl/).
 
-We staan open voor experimenten, nieuwe toepassingen en nieuwe tools (wel overtuig je eerst je collega’s van het nut ervan). Je houdt nieuwe ontwikkelingen in de gaten en past ze toe. 
+We staan open voor experimenten, nieuwe toepassingen en nieuwe tools (wel overtuig je eerst je collega’s van het nut ervan). Je houdt nieuwe ontwikkelingen in de gaten en past ze toe.
 
 In je CV komen de volgende termen voor: PHP, Python, MySQL, open source, linux, humor en GIT. Niet noodzakelijkerwijs in deze volgorde. Je hebt een relevante afgeronde HBO/WO-opleiding en minimaal 5 jaar ervaring als webontwikkelaar.
 
-NRC Digitaal is verantwoordelijk voor [nrc.nl](http://www.nrc.nl) en de digitale verschijningsvormen van NRC Handelsblad en nrc.next. We maken daarbij gebruik van Wordpress, Solr (op [zoeken.nrc.nl](http://zoeken.nrc.nl/?q=ondersteboven)), [CAS](http://en.wikipedia.org/wiki/Central_Authentication_Service) en eigen ontwikkelde applicaties in PHP en Python.
+NRC Digitaal is verantwoordelijk voor [nrc.nl](http://www.nrc.nl) en de digitale verschijningsvormen van NRC Handelsblad en nrc.next. We maken daarbij gebruik van WordPress, Solr (op [zoeken.nrc.nl](http://zoeken.nrc.nl/?q=ondersteboven)), [CAS](http://en.wikipedia.org/wiki/Central_Authentication_Service) en eigen ontwikkelde applicaties in PHP en Python.
 
 Interesse? Helaas, de vacature is gesloten.

--- a/web-developer.md
+++ b/web-developer.md
@@ -7,11 +7,11 @@ Dan ben jij degene die we zoeken.
 
 In het Nieuwe Media Team werk je aan de digitale toekomst van NRC. Dat doe je door te zorgen dat de digitale uitgaven van NRC ([nrc.nl](http://www.nrc.nl) en de apps) het beste podium voor kwaliteitsjournalistiek zijn en blijven.
 
-We staan open voor experimenten, nieuwe toepassingen en nieuwe tools (wel overtuig je eerst je collega’s van het nut ervan). Je houdt nieuwe ontwikkelingen in de gaten en past ze toe. 
+We staan open voor experimenten, nieuwe toepassingen en nieuwe tools (wel overtuig je eerst je collega’s van het nut ervan). Je houdt nieuwe ontwikkelingen in de gaten en past ze toe.
 
-In je CV komen de volgende termen voor: Python, PostgreSQL, open source, *nix en GIT. Je hebt een relevante afgeronde HBO/WO-opleiding en minimaal 5 jaar ervaring als webontwikkelaar. 
+In je CV komen de volgende termen voor: Python, PostgreSQL, open source, *nix en GIT. Je hebt een relevante afgeronde HBO/WO-opleiding en minimaal 5 jaar ervaring als webontwikkelaar.
 
-Het Nieuwe Media Team is verantwoordelijk voor [nrc.nl](http://www.nrc.nl) en de digitale verschijningsvormen van NRC Handelsblad en nrc.next. We maken daarbij gebruik van Wordpress, Elasticsearch en in-house ontwikkelde applicaties in Python, Node.js en Go.
+Het Nieuwe Media Team is verantwoordelijk voor [nrc.nl](http://www.nrc.nl) en de digitale verschijningsvormen van NRC Handelsblad en nrc.next. We maken daarbij gebruik van WordPress, Elasticsearch en in-house ontwikkelde applicaties in Python, Node.js en Go.
 
 Interesse? Stuur een pull request naar [github](https://github.com/nrcmedia/nrc-zoekt-developer/), een mention naar [@tenhoope](http://twitter.com/tenhoope) of een mail naar c.tenhoope@nrc.nl.
 


### PR DESCRIPTION
WordPress wordt met hoofdletter W en hoofdletter P geschreven.
`capital_p_dangit()`